### PR TITLE
Backticks around Region param

### DIFF
--- a/assets/eb/07-efs-mount-install.config
+++ b/assets/eb/07-efs-mount-install.config
@@ -3,7 +3,7 @@ option_settings:
     FILE_SYSTEM_ID: '<<FS_ID_HERE>>'
     MOUNT_DIRECTORY: '/var/app/current/openemr/sites/default'
 
-    REGION: '`{"Ref": "AWS::Region"}`'
+    REGION: '{"Ref": "AWS::Region"}'
 
 packages:
   yum:


### PR DESCRIPTION
These backticks were causing my Elastic Beanstalk deployment to fail. I think these might be a mistake. I'm also wondering what the EFS_DNS_NAME on line 29 is for. It doesn't appear to be used anywhere else.